### PR TITLE
update run / build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,21 @@ Now test work on (chrome, safari, firefox) no MAC OS
 ## Installation
 1.
 ```bash
-go get github.com/deepch/RTSPtoWebRTC
+$ export GO111MODULE=on
+$ go get github.com/deepch/RTSPtoWebRTC
 ```
 2.
 ```bash
-cd src/github.com/deepch/RTSPtoWebRTC
+$ cd ~/go/src/github.com/deepch/RTSPtoWebRTC
 ```
 3.
 ```bash
-go run .
+$ go run .
+```
+or
+```bash
+$ go build .
+$ ./RTSPtoWebRTC
 ```
 4.
 ```bash


### PR DESCRIPTION
could not build or run without enabling go modules.

Thus, updated to instructions.

Also inserted build instructions, as I find that particular usefull to build on my desktop and distribute the binary to my server