### PR TITLE
Add Github workflow to publish docker images when new releases are tagged

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  # Currently assumes same username / repot on both github and docker
+  # Currently assumes same username / repo on both github and docker
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,38 @@
+name: Publish Docker image
+
+on:
+  release:
+    types: [published]
+
+env:
+  # Currently assumes same username / repot on both github and docker
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2.4.0
+      
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v1.12.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v3.6.2
+        with:
+          images: ${{ env.IMAGE_NAME }}
+      
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2.7.0
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Add workflow to publish docker images when releases are made as described in #127

I've tested this for publishing a local copy of https://hub.docker.com/repository/docker/allenporter/rtsptowebrtc though assume it would make more sense to be managed by the actual project owner hence I am contributing upstream.

Some caveats of taking this on:
- Requires two repository secrets set with docker hub username and password
- Assumes the docker hub and github username and project are the same
- Requires creating github releases on significant changes