### PR TITLE
Update README to encourage use of RTSPtoWeb instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # RTSPtoWebRTC
 
-RTSP Stream to WebBrowser over WebRTC based on Pion
+RTSP Stream to WebBrowser over WebRTC based on Pion (full native! not using ffmpeg or gstreamer).
 
-full native! not use ffmpeg or gstreamer
+**Note:** [RTSPtoWeb](https://github.com/deepch/RTSPtoWeb) is an improved service that provides the same functionality, an improved API, and supports even more protocols. *RTSPtoWeb is recommended over using this service.*
+
 
 if you need RTSPtoWSMP4f use https://github.com/deepch/RTSPtoWSMP4f
 


### PR DESCRIPTION
Update readme based on discussion about making further improvements to this project.  Explicitly encourage users to visit the newer project, to reduce possible confusion.

I will redirect users to RTSPtoWeb, but want to have more opportunities to reduce confusion since many users want `WebRTC` and may not understand the differences provided by these services.