### PR TITLE
Fixed safari error TypeError: Attempted to assign to readonly property.

### DIFF
--- a/web/static/js/adapter-latest.js
+++ b/web/static/js/adapter-latest.js
@@ -1545,11 +1545,6 @@ function removeAllowExtmapMixed(window) {
   }
   var nativeSRD = window.RTCPeerConnection.prototype.setRemoteDescription;
   window.RTCPeerConnection.prototype.setRemoteDescription = function setRemoteDescription(desc) {
-    if (desc && desc.sdp && desc.sdp.indexOf('\na=extmap-allow-mixed') !== -1) {
-      desc.sdp = desc.sdp.split('\n').filter(function (line) {
-        return line.trim() !== 'a=extmap-allow-mixed';
-      }).join('\n');
-    }
     return nativeSRD.apply(this, arguments);
   };
 }

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -58,9 +58,15 @@ function getRemoteSdp() {
     data: btoa(pc.localDescription.sdp)
   }, function(data) {
     try {
+    var desc = atob(data);
+    if (desc && desc.sdp && desc.sdp.indexOf('\na=extmap-allow-mixed') !== -1) {
+      desc.sdp = desc.sdp.split('\n').filter(function (line) {
+        return line.trim() !== 'a=extmap-allow-mixed';
+      }).join('\n');
+    }
       pc.setRemoteDescription(new RTCSessionDescription({
         type: 'answer',
-        sdp: atob(data)
+        sdp: desc
       }))
     } catch (e) {
       console.warn(e);


### PR DESCRIPTION
Safari will throw error TypeError: Attempted to assign to readonly property. and will not start video. I moved problematic code from adapter-latest.js to app.js. This fixed problem and video will now start in safari. Tested with Safari 16.2.